### PR TITLE
Integrate phone number mining with web interface

### DIFF
--- a/templates/contact.html
+++ b/templates/contact.html
@@ -3,6 +3,12 @@
 <ul>
 	<li><a href="mailto:{{ c['email'] }}">{{ c['email'] }}</a></li>
 </ul>
+<h2>Mined Contact Details</h2>
+<ul>
+	{% for tel in c['tel'] %}
+        <li><a href="tel:{{ tel }}">{{ tel }}</a></li>
+        {% endfor %}
+</ul>
 <h2>Recent Mails</h2>
 <ul>
 	{% for mail in c['mails'] %}


### PR DESCRIPTION
This pull request makes the changes I was expecting to see from you to integrate the phone number scraping into the web interface. I don't believe that you actually ran the code that you committed as if you had done you would have seen this error message:

```
Traceback (most recent call last):
  File "mailmine.py", line 52, in <module>
    PN = re.findall(r'\d+', 'hello +94716772265')
NameError: name 're' is not defined
```

This is because you had not imported the modules you were using, you can see the changes I made for this on lines 1 and 10 of mailmine.py.

```
PN = re.findall(r'\d+', 'hello +94716772265')
```

In this line of code, you were not looking at the _body of the emails_ but at a fixed string. This code needs to be _integrated_ into an _application_. You've had a good chance already to explore these libraries, the code needs to all come together now.

After line 68, please now add the code for XMPP and SIP addresses. These should be easy to identify with a regular expression and will look like:

```
xmpp:irl@debian.org
sip:irl@debian.org
```

This is what the web interface should look like when you run it:

![2016-08-16-110733_869x536_scrot](https://cloud.githubusercontent.com/assets/1208651/17695891/b2179fbc-63a2-11e6-882b-24eef9023590.png)

See that the phone numbers that have been discovered are listed. The XMPP and SIP addresses that are discovered should also be presented in this list. Be sure to update the HTML template in `templates/contact.html` after making the changes to the Python code.
